### PR TITLE
UUID-fix: Empty usernames from Mojang API (status code 204: no content) no longer passed to metrics.

### DIFF
--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -1,3 +1,4 @@
+from prometheus_client import start_http_server, REGISTRY, Metric
 import time
 import requests
 import json
@@ -8,7 +9,6 @@ import schedule
 from mcrcon import MCRcon
 from os import listdir
 from os.path import isfile, join
-from prometheus_client import start_http_server, REGISTRY, Metric
 class MinecraftCollector(object):
     def __init__(self):
         self.statsdirectory = "/world/stats"
@@ -40,7 +40,7 @@ class MinecraftCollector(object):
                 self.map[uuid] = result.json()[-1]['name']
                 return(result.json()[-1]['name'])
             except:
-                return False
+                return
 
     def rcon_command(self,command):
         if self.rcon == None:
@@ -308,7 +308,7 @@ if __name__ == '__main__':
 
     start_http_server(8000)
     REGISTRY.register(MinecraftCollector())
-    print("\nExporter started on Port 8000\n")
+    print("Exporter started on Port 8000")
     while True:
         time.sleep(1)
         schedule.run_pending()


### PR DESCRIPTION
Closes #14 

The Mojang API responded with a status code 204 (No content) for some UUIDs. This is probably due to the fact that on some forge Minecraft servers, mods might add different entries to the world files that are not users but still use UUID-like entry names.

By wrapping the GET request to the Mojang API on line 39 with a try-except statement, then returning if an error should occur, the `update_metrics_for_player(self,uuid)` function can now check if a name has been returned, and if not it shall return as well (line155), so that the `collect(self)` function can check if metrics for specified UUID exist (line 297), and if not, `continue` completing the loop.

This might not be the most elegant way of solving this, but it was the fastest, easiest, and most comfortable way of solving the problem for my server.