### PR TITLE
Added configurable world directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ enable-rcon=true
 
 # Environment Variables
 
-| Name          | Default | Description                                       |
-| ------------- | ------- | ------------------------------------------------- |
-| RCON_HOST     | `None`  | Host of the RCON server                           |
-| RCON_PORT     | `None`  | Port RCON is hosted on                            |
-| RCON_PASSWORD | `None`  | RCON Password for access                          |
-| HTTP_PORT     | `8000`  | Port to host on, in case of using outside docker* |
+| Name            | Default  | Description                                       |
+| --------------- | -------- | ------------------------------------------------- |
+| RCON_HOST       | `None`   | Host of the RCON server                           |
+| RCON_PORT       | `None`   | Port RCON is hosted on                            |
+| RCON_PASSWORD   | `None`   | RCON Password for access                          |
+| HTTP_PORT       | `8000`   | Port to host on, in case of using outside docker* |
+| WORLD_DIRECTORY | `/world` | Directory of the world for player stats           |
 
 > * Or other cases where you have limited control of port mappings, eg Pterodactyl.
 

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -14,10 +14,11 @@ from prometheus_client import Metric, REGISTRY, start_http_server
 
 class MinecraftCollector(object):
     def __init__(self):
-        self.stats_directory = "/world/stats"
-        self.player_directory = "/world/playerdata"
-        self.advancements_directory = "/world/advancements"
-        self.better_questing = "/world/betterquesting"
+        self.world_directory = os.environ.get("WORLD_DIRECTORY", "/world")
+        self.stats_directory = self.world_directory + "/stats"
+        self.player_directory = self.world_directory + "/playerdata"
+        self.advancements_directory = self.world_directory + "/advancements"
+        self.better_questing = self.world_directory + "/betterquesting"
         self.player_map = dict()
         self.quests_enabled = False
 


### PR DESCRIPTION
My world directory was inside another volume and I needed to use a different path than `/world`. This change allowed me to manipulate this path.

Changes:
- Added `WORLD_DIRECTORY` environment variable. Which defaults to `/world`.
- Updated readme to include the new variable with description.