### PR TITLE
Added Usercache.json support when converting uuid to player name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # for testing
 world
+usercache.json

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker run -e RCON_HOST=127.0.0.1 \
 	   -e DYNMAP_ENABLED="True" \
 	   -p 8000:8000 \
 	   -v /opt/all_the_mods_3/world:/world \
+	   -v /opt/all_the_mods_3/usercache.json:/usercache.json \
 	   joshi425/minecraft_exporter
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,4 @@ services:
     - 9700:8000
     volumes:
     - ./world:/world:ro
+    - ./usercache.json:/usercache.json:ro

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -52,7 +52,6 @@ class MinecraftCollector(object):
     def uuid_to_player_mojang(self, uuid):
         try:
             result = requests.get('https://sessionserver.mojang.com/session/minecraft/profile/' + uuid)
-            self.player_map[uuid] = result.json()['name']
             return (result.json()['name'])
         except:
             return
@@ -64,6 +63,7 @@ class MinecraftCollector(object):
             player = self.uuid_to_player_usercache(uuid)
             if not player:
                 player = self.uuid_to_player_mojang(uuid)
+            self.player_map[uuid] = player
             return player
     
     def rcon_connect(self):

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -18,6 +18,7 @@ class MinecraftCollector(object):
         self.player_directory = "/world/playerdata"
         self.advancements_directory = "/world/advancements"
         self.better_questing = "/world/betterquesting"
+        self.usercache_file = "usercache.json"
         self.player_map = dict()
         self.quests_enabled = False
 
@@ -43,13 +44,28 @@ class MinecraftCollector(object):
         if uuid in self.player_map:
             return self.player_map[uuid]
         else:
-            try:
-                result = requests.get('https://sessionserver.mojang.com/session/minecraft/profile/' + uuid)
-                self.player_map[uuid] = result.json()['name']
-                return (result.json()['name'])
-            except:
-                return
+            name = uuid_to_player_usercache(self, uuid)
+            if not name:
+                name = uuid_to_player_mojang(self, uuid)
+            return name
 
+    def uuid_to_player_usercache(self, uuid):
+        with open(self.usercache_file) as json_file:
+            data = json.load(json_file)
+            json_file.close()
+        for user in data:
+            if user["uuid"] == uuid:
+                return user["name"]
+        return
+
+    def uuid_to_player_mojan(self, uuid):
+        try:
+            result = requests.get('https://sessionserver.mojang.com/session/minecraft/profile/' + uuid)
+            self.player_map[uuid] = result.json()['name']
+            return (result.json()['name'])
+        except:
+            return
+    
     def rcon_connect(self):
         try:
             self.rcon.connect()

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -66,7 +66,7 @@ class MinecraftCollector(object):
                 player = self.uuid_to_player_mojang(uuid)
             return player
     
-    def Rcon_connect(self):
+    def rcon_connect(self):
         try:
             self.rcon.connect()
             self.rcon_connected = True

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -18,7 +18,7 @@ class MinecraftCollector(object):
         self.player_directory = "/world/playerdata"
         self.advancements_directory = "/world/advancements"
         self.better_questing = "/world/betterquesting"
-        self.usercache_file = "usercache.json"
+        self.usercache_file = "/usercache.json"
         self.player_map = dict()
         self.quests_enabled = False
 
@@ -40,15 +40,6 @@ class MinecraftCollector(object):
         print("flushing playername cache")
         self.player_map = dict()
 
-    def uuid_to_player(self, uuid):
-        if uuid in self.player_map:
-            return self.player_map[uuid]
-        else:
-            name = uuid_to_player_usercache(self, uuid)
-            if not name:
-                name = uuid_to_player_mojang(self, uuid)
-            return name
-
     def uuid_to_player_usercache(self, uuid):
         with open(self.usercache_file) as json_file:
             data = json.load(json_file)
@@ -58,15 +49,24 @@ class MinecraftCollector(object):
                 return user["name"]
         return
 
-    def uuid_to_player_mojan(self, uuid):
+    def uuid_to_player_mojang(self, uuid):
         try:
             result = requests.get('https://sessionserver.mojang.com/session/minecraft/profile/' + uuid)
             self.player_map[uuid] = result.json()['name']
             return (result.json()['name'])
         except:
             return
+        
+    def uuid_to_player(self, uuid):
+        if uuid in self.player_map:
+            return self.player_map[uuid]
+        else:
+            player = self.uuid_to_player_usercache(uuid)
+            if not player:
+                player = self.uuid_to_player_mojang(uuid)
+            return player
     
-    def rcon_connect(self):
+    def Rcon_connect(self):
         try:
             self.rcon.connect()
             self.rcon_connected = True


### PR DESCRIPTION
The exporter was throwing away data from bedrock players connecting with Geyser/floodgate due to no being able to lookup their username from the online mojang service. I added in a check to try and pull the username first from the usercache.json file with a fallback of the online service.