### PR TITLE
Fix crash on freshly created server

### DIFF
--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -33,7 +33,7 @@ class MinecraftCollector(object):
         schedule.every().day.at("01:00").do(self.flush_playernamecache)
 
     def get_players(self):
-        if self.rcon is None or (not self.rcon_connected and not self.rcon_connect()):
+        if not os.path.isdir(self.stats_directory):
             return []
         return [f[:-5] for f in listdir(self.stats_directory) if isfile(join(self.stats_directory, f))]
 

--- a/minecraft_exporter.py
+++ b/minecraft_exporter.py
@@ -33,6 +33,8 @@ class MinecraftCollector(object):
         schedule.every().day.at("01:00").do(self.flush_playernamecache)
 
     def get_players(self):
+        if self.rcon is None or (not self.rcon_connected and not self.rcon_connect()):
+            return []
         return [f[:-5] for f in listdir(self.stats_directory) if isfile(join(self.stats_directory, f))]
 
     def flush_playernamecache(self):


### PR DESCRIPTION
This also enables the container to run as a Kubernetes pod sidecar without creating a crash loop.